### PR TITLE
Fix: correctly save/load key bindings and wire subcommands

### DIFF
--- a/BindingsManager.lua
+++ b/BindingsManager.lua
@@ -10,34 +10,67 @@ local SetBinding = SetBinding
 local SaveBindings = SaveBindings
 local GetCurrentBindingSet = GetCurrentBindingSet
 
+local L = ns.L or {} -- fallback if localization table is not available
+
+-- Ensure DB exists
+RuilhennDB = RuilhennDB or {}
 
 function BindingsManager:Save()
+    -- Save current binding set id so we can restore to the same set later
+    local bindingSet = GetCurrentBindingSet()
     local bindings = {}
+
     for i = 1, GetNumBindings() do
         local command, key1, key2 = GetBinding(i)
-        table.insert(bindings, { command = command, key1 = key1, key2 = key2 })
+        -- Normalize empty-string keys to nil; only save entries that have a command and at least one key
+        if command and command ~= "" and (key1 and key1 ~= "" or key2 and key2 ~= "") then
+            table.insert(bindings, {
+                command = command,
+                key1 = (key1 and key1 ~= "") and key1 or nil,
+                key2 = (key2 and key2 ~= "") and key2 or nil,
+            })
+        end
     end
+
     RuilhennDB.keyBindings = bindings
-    ns.Log:Debug(L["KEY_BINDINGS_SAVED"])
+    RuilhennDB.bindingSet = bindingSet
+
+    -- Use Info for user-visible messages; fall back to a plain string if localization is missing
+    ns.Log:Info(L["KEY_BINDINGS_SAVED"] or "Key bindings saved.")
 end
 
 function BindingsManager:Load()
-    if RuilhennDB.keyBindings then
-        for _, bind in ipairs(RuilhennDB.keyBindings) do
-            SetBinding(bind.key1, bind.command)
-            SetBinding(bind.key2, bind.command)
-        end
-        SaveBindings(GetCurrentBindingSet())
-        ns.Log:Debug(L["KEY_BINDINGS_LOADED"])
+    if not RuilhennDB or not RuilhennDB.keyBindings then
+        ns.Log:Debug("BindingsManager:Load called but no saved bindings exist.")
+        return
     end
+
+    -- Apply saved bindings. Only set bindings if both key and command exist.
+    for _, bind in ipairs(RuilhennDB.keyBindings) do
+        if bind and bind.command then
+            if bind.key1 then
+                SetBinding(bind.key1, bind.command)
+            end
+            if bind.key2 then
+                SetBinding(bind.key2, bind.command)
+            end
+        end
+    end
+
+    -- Restore to the saved binding set if available; otherwise save to current.
+    local targetSet = RuilhennDB.bindingSet or GetCurrentBindingSet()
+    SaveBindings(targetSet)
+
+    ns.Log:Info(L["KEY_BINDINGS_LOADED"] or "Key bindings loaded.")
 end
 
+-- Subcommands should actually call the methods above
 BindingsManager.subcommands = {
     ["load"] = function()
-        ns.Log:Debug("BindingsManager:Load")
+        BindingsManager:Load()
     end,
     ["save"] = function()
-        ns.Log:Debug("BindingsManager:Save")
+        BindingsManager:Save()
     end
 }
 
@@ -45,11 +78,12 @@ Commands["bindings"] = function(subcommand)
     local func = BindingsManager.subcommands[subcommand]
 
     if type(func) ~= "function" then
+        ns.Log:Debug("bindings: unknown subcommand " .. tostring(subcommand))
         return
     end
 
     local success, err = pcall(func)
     if not success then
-        ns.Log:Debug("Command execution error: " .. err)
+        ns.Log:Debug("Command execution error: " .. tostring(err))
     end
 end

--- a/BindingsManager.lua
+++ b/BindingsManager.lua
@@ -23,7 +23,9 @@ function BindingsManager:Save()
     for i = 1, GetNumBindings() do
         local command, key1, key2 = GetBinding(i)
         -- Normalize empty-string keys to nil; only save entries that have a command and at least one key
-        if command and command ~= "" and (key1 and key1 ~= "" or key2 and key2 ~= "") then
+        local normKey1 = (key1 and key1 ~= "") and key1 or nil
+        local normKey2 = (key2 and key2 ~= "") and key2 or nil
+        if command and command ~= "" and (normKey1 or normKey2) then
             table.insert(bindings, {
                 command = command,
                 key1 = (key1 and key1 ~= "") and key1 or nil,
@@ -35,8 +37,8 @@ function BindingsManager:Save()
     RuilhennDB.keyBindings = bindings
     RuilhennDB.bindingSet = bindingSet
 
-    -- Use Info for user-visible messages; fall back to a plain string if localization is missing
-    ns.Log:Info(L["KEY_BINDINGS_SAVED"] or "Key bindings saved.")
+    -- Use Message for user-visible messages; fall back to a plain string if localization is missing
+    ns.Log:Message(L["KEY_BINDINGS_SAVED"] or "Key bindings saved.")
 end
 
 function BindingsManager:Load()
@@ -61,7 +63,7 @@ function BindingsManager:Load()
     local targetSet = RuilhennDB.bindingSet or GetCurrentBindingSet()
     SaveBindings(targetSet)
 
-    ns.Log:Info(L["KEY_BINDINGS_LOADED"] or "Key bindings loaded.")
+    ns.Log:Message(L["KEY_BINDINGS_LOADED"] or "Key bindings loaded.")
 end
 
 -- Subcommands should actually call the methods above


### PR DESCRIPTION
Summary

    Fixes a bug where the "bindings" subcommands only logged an action instead of actually calling BindingsManager:Save() and BindingsManager:Load().
    Improves safety and robustness when saving/loading key bindings.

What changed

    BindingsManager.Save now:
        Skips empty / nil keys when saving.
        Normalizes empty-string keys to nil.
        Saves the current binding set id (RuilhennDB.bindingSet) so Load can restore the same set.
        Ensures RuilhennDB exists before writing.
        Uses a user-visible Info log for success messages (falls back to a literal string if localization is missing).
    BindingsManager.Load now:
        Checks for the presence of saved bindings before attempting to load.
        Only calls SetBinding when a saved key exists.
        Calls SaveBindings with the saved binding set id (or the current set if none was saved).
        Uses a user-visible Info log for success messages.
    Subcommand wiring:
        The "load" and "save" subcommand handlers now call BindingsManager:Load() and BindingsManager:Save(), respectively (previously they only logged).

Files changed

    BindingsManager.lua — replaced Save/Load implementations and fixed subcommand wiring.

Testing notes / QA checklist

    Run the save command and verify RuilhennDB.keyBindings is created and populated.
    Verify RuilhennDB.bindingSet is set to the current binding set id when saved.
    Run the load command and confirm bindings are reapplied (check that SetBinding is invoked only for non-empty saved keys).
    Confirm SaveBindings is called with the saved binding set id (or with the current set if no id was saved).
    Test edge cases:
        No saved bindings exist (Load should exit cleanly and log a debug message).
        Saved entries contain empty strings (these should be ignored / normalized).
        Conflicting existing bindings (verify current behavior or note in review if an overwrite/clear strategy is desired).
    Verify that running the commands via the UI/console that route through Commands["bindings"] with subcommands "save" and "load" actually execute the behavior (not just log).

Backward compatibility & risks

    This change only modifies how bindings are saved/loaded and how the subcommands are wired; it should be backward-compatible.
    Risk: loading saved bindings can overwrite existing user bindings. Consider whether an explicit confirmation/overwrite strategy is needed for end users.

Suggested reviewers / labels

    Reviewers: someone familiar with keybinding behavior and the addon command/persistence system.
    Labels: bug, enhancement, needs-testing

Notes / follow-ups

    Consider an option to clear or unbind conflicting keys before applying saved bindings (prevents duplicate binding collisions).
    Consider storing whether the bindings were character-specific vs account-wide if your addon needs to support both modes.
